### PR TITLE
Add SPDX license identifier

### DIFF
--- a/src/RsaVerify.sol
+++ b/src/RsaVerify.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 /*


### PR DESCRIPTION
Adds the [license identifier](https://docs.soliditylang.org/en/latest/layout-of-source-files.html#spdx-license-identifier) in the smart contract removing the compilation warning `Warning: SPDX license identifier not provided in source file`.